### PR TITLE
SelfQuotingVectors: Chicken does self-quote

### DIFF
--- a/surveys/SelfQuotingVectors.md
+++ b/surveys/SelfQuotingVectors.md
@@ -1,6 +1,6 @@
-Currently Racket, Gauche, MIT, Bigloo, Guile, Kawa, Chibi, SCM, NexJ, STklos, Shoe, TinyScheme, Scheme 9, Dream, s7, XLisp, Rep, Schemik, UMB, VX, Oaklisp, Llava, Spark, FemtoLisp, Dfsch, Owl Lisp, Sagittarius treat vectors as self-quoting.
+Currently Racket, Gauche, MIT, Bigloo, Guile, Kawa, Chibi, SCM, NexJ, STklos, Shoe, TinyScheme, Scheme 9, Dream, s7, XLisp, Rep, Schemik, UMB, VX, Oaklisp, Llava, Spark, FemtoLisp, Dfsch, Owl Lisp, Sagittarius, Chicken treat vectors as self-quoting.
 
-Gambit, Chicken, Scheme48/scsh, SISC, Chez, Ikarus/Vicare, Ypsilon, Mosh, IronScheme, KSi, SigScheme, RScheme, Elk, SXM, Sizzle, Inlab treat unquoted vectors as errors.
+Gambit, Scheme48/scsh, SISC, Chez, Ikarus/Vicare, Ypsilon, Mosh, IronScheme, KSi, SigScheme, RScheme, Elk, SXM, Sizzle, Inlab treat unquoted vectors as errors.
 
 Larceny prints a warning from the macro expander, but then treats the vector as self-quoting.
 


### PR DESCRIPTION
Chicken 5 does quote vectors (both from the REPL and compiled code).

```
#;1> #(2 3 4) 
#(2 3 4)   
```
                                                                                                                                                                                                                           
```
$ cat > test.scm    
(display #(2 3))
(newline)
$ csc test.scm
$ ./test 
#(2 3)
```