### PR TITLE
WhatLoadReturns: add STklos' behavior

### DIFF
--- a/surveys/WhatLoadReturns.md
+++ b/surveys/WhatLoadReturns.md
@@ -1,6 +1,6 @@
 Asked to load a file containing the text `(values 1 2 3)`, Racket, Scheme48/scsh, Guile, RScheme return `1 2 3` (3 values).
 
-Chicken, Kawa, SISC, Chibi, Chez, Ikarus/Vicare, Larceny, Ypsilon, SigScheme return their standard
+Chicken, Kawa, SISC, Chibi, Chez, Ikarus/Vicare, Larceny, Ypsilon, SigScheme, STklos return their standard
 undefined-value object.
 
 Gauche returns `#t 2 3` (3 values).


### PR DESCRIPTION
STklos' `load` returns `#void`, which can be verified to be `eq?` to `(if #f #f)` and to `#void`.

```
stklos> (define x (load "file"))
stklos> (define y (if #f #f))
stklos> (eq? x y)
#t
stklos> (eq? x #void)
#t
```