### PR TITLE
EmptyList: Chibi signals an error

### DIFF
--- a/surveys/EmptyList.md
+++ b/surveys/EmptyList.md
@@ -1,8 +1,8 @@
-The empty list is self-evaluating in Gauche, MIT, Kawa, SISC, Chibi,
+The empty list is self-evaluating in Gauche, MIT, Kawa, SISC, 
 SCM, NexJ, STklos, SigScheme, TinyScheme, Scheme 9, Dream, S7, BDC,
 Xlisp, Rep, Jscheme, Schemik, VX, Oaklisp, Sizzle, Spark, Femtolisp, Dfsch, Inlab, Owl Lisp, Sagittarius.
 
-Racket, Gambit, Chicken, Bigloo, Guile, Scheme48/scsh, Chez, Ikarus/Vicare, Larceny, Ypsilon, Mosh, IronScheme, KSi, Shoe, Elk, RScheme, UMB, Llava, SXM,  signal a syntax error.
+Chibi, Racket, Gambit, Chicken, Bigloo, Guile, Scheme48/scsh, Chez, Ikarus/Vicare, Larceny, Ypsilon, Mosh, IronScheme, KSi, Shoe, Elk, RScheme, UMB, Llava, SXM,  signal an error.
 
 Larceny signals a syntax warning but then treats the empty list as self-evaluating.
 


### PR DESCRIPTION
```
$ chibi-scheme
> ()
ERROR: empty application in source: ()
```

However, that is not a _syntax_ error -- it's an evaluation error.