### PR TITLE
Add log-requires-floating-point

### DIFF
--- a/surveys/log-requires-floating-point.md
+++ b/surveys/log-requires-floating-point.md
@@ -1,0 +1,42 @@
+# Log requires floating point?
+
+Does `log` need to be computed using floating-point representation?
+This excludes the larger part of bignums.
+
+This is a test:
+
+```
+(define x (expt 10 2480))
+(log x)
+```
+
+If the implementation wants to answer `(log x)` with the correct
+number, the logarithm must be calculated without the floating-point 
+C library log function, since the number is far too large to fit 
+in current days 64-bit doubles.
+
+|System      | result |
+|------------|--------|
+|Bigloo      | -inf.0 |
+|Biwa        | +inf.0 |
+|Chez        | 5710.411030625233 |
+|Chibi       | +inf.0 |
+|Chicken     | +inf.0 |
+|Cyclone     | +inf.0 |
+|Foment      | +inf.0 |
+|Gambit      | 5710.411030625233 |
+|Gauche      | 5710.411030625233 |
+|Guile       | 5710.411030625233 |
+|Kawa        | +inf.0 |
+|LIPS        | +inf.0 |
+|Loko        | +inf.0 |
+|MIT         | +inf.0 |
+|Sagittarius | 5710.411030625233 |
+|Scheme 9    | 5710.41103062521399 |
+|STklos      | +inf.0 |
+|Tinyscheme  | +inf.0 |
+|Unsyntax    | +inf.0 |
+|Ypsilon     | 5710.411030625233
+
+* Biwa and Tinyscheme already compute `x` as the inexact infinity `+inf.0`
+

--- a/surveys/log-requires-floating-point.md
+++ b/surveys/log-requires-floating-point.md
@@ -39,9 +39,14 @@ in current days 64-bit doubles.
 |Unsyntax    | +inf.0 |
 |Ypsilon     | 5710.411030625233
 |            |          |
-|Common Lisp | 5710.411 |
+| ABCL       | error    |
+| CCL        | 5710.411 |
+| Clisp      | 5710.411 |
+| CMUCL      | 5710.411 |
+| ECL        | 5710.411 |
+| SBCL       | 5710.411 |
+|            |          |
 |Emacs Lisp  | 1.0e+INF |
 
 
 * Biwa and Tinyscheme already compute `x` as the inexact infinity `+inf.0`.
-* The Common Lisp standard requires that the implementations compute this answer correctly.

--- a/surveys/log-requires-floating-point.md
+++ b/surveys/log-requires-floating-point.md
@@ -37,6 +37,10 @@ in current days 64-bit doubles.
 |Tinyscheme  | +inf.0 |
 |Unsyntax    | +inf.0 |
 |Ypsilon     | 5710.411030625233
+|            |          |
+|Common Lisp | 5710.411 |
+|Emacs Lisp  | 1.0e+INF |
 
-* Biwa and Tinyscheme already compute `x` as the inexact infinity `+inf.0`
 
+* Biwa and Tinyscheme already compute `x` as the inexact infinity `+inf.0`.
+* The Common Lisp standard requires that the implementations compute this answer correctly.

--- a/surveys/log-requires-floating-point.md
+++ b/surveys/log-requires-floating-point.md
@@ -31,6 +31,7 @@ in current days 64-bit doubles.
 |LIPS        | +inf.0 |
 |Loko        | +inf.0 |
 |MIT         | +inf.0 |
+|Racket      | 5710.411030625233 |
 |Sagittarius | 5710.411030625233 |
 |Scheme 9    | 5710.41103062521399 |
 |STklos      | +inf.0 |

--- a/surveys/log-requires-floating-point.md
+++ b/surveys/log-requires-floating-point.md
@@ -50,3 +50,17 @@ in current days 64-bit doubles.
 
 
 * Biwa and Tinyscheme already compute `x` as the inexact infinity `+inf.0`.
+
+
+Another experiment:
+
+```
+(log 1/6319748715279270675921934218987893281199411530039296)
+```
+Should return -119.27551918982401. (This was posted to the ECL mailing list on 2022-Jul-03 -- ECL does not compute the value, and complains about the user requesting log of zero).
+
+* Cyclone needs the number to be given as explicit division (doesn't support rationals), and returns `-inf.0`
+* Loko returns `-inf.0`
+* Tinyscheme needs the number to be given as explicit division (doesn't support rationals), and returns `-43.66827238`
+
+All others return the correct result; Bigloo and Scheme9 need the rational to be described as division, not as rational type.

--- a/www-index.scm
+++ b/www-index.scm
@@ -113,6 +113,7 @@
   "exact-sqrt"
   "fixnum-info"
   "float-precision"
+  "log-requires-floating-point"
   "max-inf-nan"
   "negative-rationalize"
   "negative-sqrt"


### PR DESCRIPTION
Is `(log x)` calculated correctly when x is a bignum that doesn't fit in an inexact real?