### PR TITLE
Rename time -> profiling

### DIFF
--- a/surveys/letrec-star.md
+++ b/surveys/letrec-star.md
@@ -6,7 +6,7 @@ This page reports the results of the expressions `(letrec ((x 0) (y x)) y)` and 
 (let ((z 0))
   (define x 0)
   (define y x)
-y)
+  y)
 ```
 
 which in R5RS and earlier is defined to be the same as the `letrec` version, and in R6RS and R7RS is defined to be the same as the `letrec*` version.

--- a/surveys/profiling.md
+++ b/surveys/profiling.md
@@ -1,4 +1,6 @@
-# Convenience `time` macro
+# Profiling
+
+## Simple timing
 
 Most Lisps have a `time` macro that measures the execution time of
 code.
@@ -39,9 +41,10 @@ code.
              (newline)))
 ```
 
+Other Lisps:
+
 | System | Method | Procedure or Syntax |
 |---|---|---|
 | elisp | n/a |  |
 | Common Lisp | `time` | syntax |
 | Clojure | `time` | syntax |
-

--- a/www-index.scm
+++ b/www-index.scm
@@ -10,10 +10,10 @@
   "load-path"
   "minischeme-history"
   "optionality"
+  "profiling"
   "scheme-number-implementations"
   "scheme-on-windows"
-  "standalone-executables"
-  "time")
+  "standalone-executables")
 
  ("Macros"
   "macroexpand"


### PR DESCRIPTION
@jpellegrini Is it OK to rename the survey?

The word "time" has many meanings (e.g. current time of day, timestamps, ...).

"Timing" is a less ambiguous word, but perhaps we should do a general "profiling" survey? The boundary between timing and profiling is blurry; some of the fancier timers in this survey arguably count as simple profilers.