### PR TITLE
Add RnRS support page to features section

### DIFF
--- a/surveys/rnrs-support.md
+++ b/surveys/rnrs-support.md
@@ -11,7 +11,7 @@ Scheme systems grouped by the Scheme standards they support:
 | Cyclone     |      |      |      | x    |
 | Foment      |      |      |      | x    |
 | Gambit      |      | x    |      | x    |
-| Gauche      |      | x    | x    | x    |
+| Gauche      |      | x    |      | x    |
 | Guile       |      |      | x    | x    |
 | Kawa        |      | x    | x    | x    |
 | Lips        |      | x    |      | x    |

--- a/surveys/rnrs-support.md
+++ b/surveys/rnrs-support.md
@@ -1,0 +1,27 @@
+# RnRS support
+
+Scheme systems grouped by the Scheme standards they support:
+
+| System      | R4RS | R5RS | R6RS | R7RS |
+|-------------|------|------|------|------|
+| Biwa        |      |      | x    | x    |
+| Chez        |      |      | x    |      |
+| Chibi       |      |      |      | x    |
+| Chicken     |      | x    |      | x*   |
+| Cyclone     |      |      |      | x    |
+| Foment      |      |      |      | x    |
+| Gambit      |      | x    |      | x    |
+| Gauche      |      | x    | x    | x    |
+| Guile       |      |      | x    | x    |
+| Kawa        |      | x    | x    | x    |
+| Lips        |      | x    |      | x    |
+| Loko        |      |      | x    | x    |
+| MIT         | x    |      |      | x    |
+| Racket      |      | x    | x    | x*   |
+| Sagittarius |      |      | x    | x    |
+| Stklos      |      | x    |      | x    |
+| Unsyntax    |      |      |      | x    |
+| Ypsilon     |      |      | x    | x    |
+
+- Chicken: R7RS conformance is achieved via [r7rs egg](https://wiki.call-cc.org/eggref/5/r7rs)
+- Racket: R7RS support is achieved via [community-provided #lang](https://github.com/lexi-lambda/racket-r7rs/)

--- a/www-index.scm
+++ b/www-index.scm
@@ -10,6 +10,7 @@
   "load-path"
   "optionality"
   "profiling"
+  "rnrs-support"
   "scheme-number-implementations"
   "scheme-on-windows"
   "standalone-executables")


### PR DESCRIPTION
Someone on IRC asked about which implementations support which RnRS standard, so I added a page. Apologies if it does already exist.

I took the list of surveyed implementations from boolean-equal.md and added Guile. Please let me know if any entry looks incorrect or if there's more implementations that should be added.