### PR TITLE
Add more RnRS support impls

### DIFF
--- a/surveys/rnrs-support.md
+++ b/surveys/rnrs-support.md
@@ -23,5 +23,5 @@ Scheme systems grouped by the Scheme standards they support:
 | Unsyntax    |      |      |      | x    |
 | Ypsilon     |      |      | x    | x    |
 
-- Chicken: R7RS conformance is achieved via [r7rs egg](https://wiki.call-cc.org/eggref/5/r7rs)
+- Chicken: R7RS support is achieved via [r7rs egg](https://wiki.call-cc.org/eggref/5/r7rs)
 - Racket: R7RS support is achieved via [community-provided #lang](https://github.com/lexi-lambda/racket-r7rs/)

--- a/surveys/rnrs-support.md
+++ b/surveys/rnrs-support.md
@@ -4,20 +4,27 @@ Scheme systems grouped by the Scheme standards they support:
 
 | System      | R4RS | R5RS | R6RS | R7RS |
 |-------------|------|------|------|------|
+| Bigloo      |      | x    |      |      |
 | Biwa        |      |      | x    | x    |
+| Bones       | x    |      |      |      |
 | Chez        |      |      | x    |      |
 | Chibi       |      |      |      | x    |
 | Chicken     |      | x    |      | x*   |
 | Cyclone     |      |      |      | x    |
+| Femtolisp   |      | x    |      |      |
 | Foment      |      |      |      | x    |
 | Gambit      |      | x    |      | x    |
+| Gerbil      |      | x    |      | x    |
 | Gauche      |      | x    |      | x    |
 | Guile       |      |      | x    | x    |
+| Iron Scheme |      |      | x    |      |
 | Kawa        |      | x    | x    | x    |
 | Lips        |      | x    |      | x    |
 | Loko        |      |      | x    | x    |
 | MIT         | x    |      |      | x    |
 | Racket      |      | x    | x    | x*   |
+| S7          |      | x    |      | x    |
+| S9fes       | x    |      |      |      |
 | Sagittarius |      |      | x    | x    |
 | Stklos      |      | x    |      | x    |
 | Unsyntax    |      |      |      | x    |


### PR DESCRIPTION
It occurred me that people do take the [r7rs-benchmarks](https://ecraven.github.io/r7rs-benchmarks/) seriously and some of the implementations listed there were missing, so I added them to the page.