### PR TITLE
Add "complex-conjugate"

### DIFF
--- a/surveys/complex-conjugate.md
+++ b/surveys/complex-conjugate.md
@@ -1,0 +1,25 @@
+# Complex conjugate
+
+Which Scheme implementations have a core procedure for computing the
+complex conjugate of a number?
+
+| System      | procedure   | obs          |
+|-------------|-------------|--------------|
+| Bigloo      |             |              |
+| Biwa        |             | No complexes |
+| Chibi       |             |              |
+| Chicken     |             |              |
+| Chez        | `conjugate` |              |
+| Cyclone     |             |              |
+| Gambit      | `conjugate` |              |
+| Gauche      |             |              |
+| Guile       |             |              |
+| Kawa        |             |              |
+| LIPS        |             |              |
+| Loko        |             |              |
+| MIT         | `conjugate` |              |
+| Racket      | `conjugate` |              |
+| Sagittarius |             |              |
+| Scheme9     |             | No complexes |
+| STklos      |             |              |
+| Unsyntax    |             |              |

--- a/www-index.scm
+++ b/www-index.scm
@@ -111,6 +111,7 @@
   "unicode-support")
 
  ("Numbers"
+  "complex-conjugate"
   "complex-logarithm"
   "complex-representations"
   "exact-expt"


### PR DESCRIPTION
Although R7RS standardizes procedures related to complex numbers, a procedure for computing the complex conjugate was not included. Which Scheme implementations have a core procedure for computing the complex conjugate of a number?