### PR TITLE
move Kawa in define-syntax-defines survey

### DIFF
--- a/surveys/define-syntax-defines.md
+++ b/surveys/define-syntax-defines.md
@@ -13,7 +13,7 @@ x => ???
 to see whether I got 32 as the value of x or blew up on an error such
 as invalid syntax (in the define-syntax) or undefined variable.
 
-Racket, MIT, Gambit, scsh/Scheme48, SISC, Chez, Ikarus/Vicare, Ypsilon, Mosh IronScheme, NexJ, KSi, SigScheme, Shoe, TinyScheme, Dream, RScheme, S7, XLisp, Rep, Schemik, ELK, UMB, VX, Oaklisp, Llava, Sizzle, Spark, Femtolisp, Dfsch, Inlab, Owl Lisp, Sagittarius blew up (some of them because they don't support syntax-rules).
+Racket, MIT, Gambit, Kawa, scsh/Scheme48, SISC, Chez, Ikarus/Vicare, Ypsilon, Mosh IronScheme, NexJ, KSi, SigScheme, Shoe, TinyScheme, Dream, RScheme, S7, XLisp, Rep, Schemik, ELK, UMB, VX, Oaklisp, Llava, Sizzle, Spark, Femtolisp, Dfsch, Inlab, Owl Lisp, Sagittarius blew up (some of them because they don't support syntax-rules).
 
-Gauche, Chicken, Bigloo, Guile, Kawa, Chibi, SCM, Larceny (in R5RS mode), Scheme 9,
+Gauche, Chicken, Bigloo, Guile, Chibi, SCM, Larceny (in R5RS mode), Scheme 9,
 STklos, SigScheme, BDC, SXM, VSCM were fine with it and returned 32.


### PR DESCRIPTION
Kawa output:

```scheme
$ kawa syntax-define.scm 
syntax-define.scm:6:10: warning - no declaration seen for x
syntax-define.scm:6:10: unbound location: x
	at gnu.mapping.DynamicLocation.get(DynamicLocation.java:36)
	at syntax-define.run(syntax-define.scm:6)
	at gnu.expr.ModuleExp.evalModule2(ModuleExp.java:290)
	at gnu.expr.CompiledModule.evalModule(CompiledModule.java:42)
	at gnu.expr.CompiledModule.evalModule(CompiledModule.java:60)
	at kawa.Shell.runFile(Shell.java:571)
	at kawa.Shell.runFileOrClass(Shell.java:474)
	at kawa.repl.processArgs(repl.java:710)
	at kawa.repl.main(repl.java:830)
$ kawa --version
Kawa 3.1.1 (git describe: 3.1.1-0-gc47de33ad)
Copyright (C) 2020 Per Bothner
$ cat syntax-define.scm
(define-syntax foo
    (syntax-rules ()
      ((foo) (define x 32))))

(foo)
(display x)
(newline)
```