### PR TITLE
Fix link to USENET post about the Petrofsky Catastrophe 

### DIFF
--- a/surveys/petrofsky-catastrophe.md
+++ b/surveys/petrofsky-catastrophe.md
@@ -1,6 +1,6 @@
 # Petrofsky catastrophe
 
-This is a test of the expression `(call-with-current-continuation (lambda (c) (0 (c 1))))` as described in [this comp.lang.scheme thread](https://groups.google.com/forum/#!topic/comp.lang.scheme/J2ut9mbyQrU%5B1-25-false%5D) against the usual suite of Schemes.
+This is a test of the expression `(call-with-current-continuation (lambda (c) (0 (c 1))))` as described in [this comp.lang.scheme thread](https://groups.google.com/g/comp.lang.scheme/c/J2ut9mbyQrU/m/UbZCSoA4XhQJ) against the usual suite of Schemes.
 
 Returns `1`:  Racket, Gauche, MIT, Gambit, Chicken, Bigloo, Guile, Chez, Vicare, Larceny, Ypsilon, Mosh, NexJ, STklos, KSi, Peroxide, Shoe, TinyScheme, Scheme9, RScheme, S7, BDC, XLisp, Rep, UMB, SXM, Sagittarius
 


### PR DESCRIPTION
The old link was dead.